### PR TITLE
Allow eye surgeries while patient wears mask

### DIFF
--- a/Content.Shared/_Starlight/Medical/Surgery/Components/_Conditions.cs
+++ b/Content.Shared/_Starlight/Medical/Surgery/Components/_Conditions.cs
@@ -60,7 +60,10 @@ public sealed partial class SurgeryOrganDontExistConditionComponent : Component
 {
     [DataField]
     public ComponentRegistry? Organ;
-    
+
     [DataField]
     public string? Container;
 }
+
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedSurgerySystem))]
+public sealed partial class SurgeryAllowMaskComponent : Component;

--- a/Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs
+++ b/Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs
@@ -331,6 +331,9 @@ public abstract partial class SharedSurgerySystem
             _ => SlotFlags.NONE
         };
 
+        if (HasComp<SurgeryAllowMaskComponent>(step))
+            slot &= ~SlotFlags.MASK;
+
         var check = new SurgeryCanPerformStepEvent(user, body, GetTools(user), slot);
         RaiseLocalEvent(step, ref check);
         popup = check.Popup;

--- a/Resources/Prototypes/_StarLight/Surgery/organs_steps.yml
+++ b/Resources/Prototypes/_StarLight/Surgery/organs_steps.yml
@@ -262,6 +262,7 @@
   components:
   - type: SurgeryStep
     duration: 2
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
     layers:
@@ -277,6 +278,7 @@
     duration: 3
     tools:
     - type: Hemostat
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scissors.rsi
     state: hemostat
@@ -294,6 +296,7 @@
   - type: SurgeryStepOrganExtract
     organ:
     - type: OrganEyes
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
     state: scalpel
@@ -306,6 +309,7 @@
   components:
   - type: SurgeryStep
     duration: 2
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Medical/implants.rsi
     layers:
@@ -324,6 +328,7 @@
   - type: SurgeryStepOrganExtract
     organ:
     - type: EyeImplant
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
     state: scalpel
@@ -788,6 +793,7 @@
     duration: 2
     tools:
     - type: Scalpel
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
     state: scalpel
@@ -803,6 +809,7 @@
     - type: OrganEyes
   - type: SurgeryStepOrganInsert
     slot: eyes
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
     layers:
@@ -818,6 +825,7 @@
     duration: 4
     tools:
     - type: Hemostat
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scissors.rsi
     state: hemostat
@@ -835,6 +843,7 @@
     - type: EyeImplant
   - type: SurgeryStepOrganInsert
     slot: eye_implant
+  - type: SurgeryAllowMask
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Medical/implants.rsi
     layers:


### PR DESCRIPTION
## Summary
- allow masks during eye surgeries
- mark eye surgery steps as mask-allowed

## Testing
- `dotnet format --include Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs Content.Shared/_Starlight/Medical/Surgery/Components/_Conditions.cs` *(fails: A compatible .NET SDK was not found)*
- `dotnet test` *(fails: A compatible .NET SDK was not found)*
- `dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e886da2148329bca439dffff21206